### PR TITLE
Confirmation dialogs

### DIFF
--- a/src/common/misc.js
+++ b/src/common/misc.js
@@ -3,4 +3,7 @@ const trace = x => {
     return x;
 };
 
-export { trace };
+const isPromise = x => x?.then ? true : false;
+const first = x => ( _.isArray(x) && x.length ) > 0 ? x[0] : null;
+
+export { trace, isPromise, first };

--- a/src/components/data_aware/complex_form.js
+++ b/src/components/data_aware/complex_form.js
@@ -12,8 +12,10 @@ function ComplexForm(context, complexId, parentNodeId) {
         ComplexFormDom,
         DataToolbar,
         ModalSearch,
-        UIkit
+        UIkit,
     } = context,
+          self = {},
+          translate = context.i18n.translate,
           provider = ComplexFormProvider(context),
           formDom = ComplexFormDom(context, parentNodeId),
           refresh = () => build(load());
@@ -53,21 +55,24 @@ function ComplexForm(context, complexId, parentNodeId) {
 
     function build(loaded) {
         built = loaded.then(
-            data => complexForm(
-                data["title"],
-                smartFields(
-                    {
-                        ...context,
-                        fieldsDefs: data["fields-defs"],
-                        dataFields: dataProvider.dataset.fields(),
-                    }
-                ),
-                null,
-                DataToolbar(
-                    { ...context, dataProvider, search },
-                    [actionGroups.nav, actionGroups.crud, actionGroups.additional],
-                ).hiccup(),
-            )
+            data => {
+                self.title = data["title"];
+                return complexForm(
+                    data["title"],
+                    smartFields(
+                        {
+                            ...context,
+                            fieldsDefs: data["fields-defs"],
+                            dataFields: dataProvider.dataset.fields(),
+                        }
+                    ),
+                    null,
+                    DataToolbar(
+                        { ...context, dataProvider, search },
+                        [actionGroups.nav, actionGroups.crud, actionGroups.additional],
+                    ).hiccup(),
+                );
+            }
         );
         return built;
     }
@@ -83,16 +88,23 @@ function ComplexForm(context, complexId, parentNodeId) {
         return UIkit.modal.confirm("Tem certeza????");
     }
 
-    function setDatasetEventHandlers(args) {
-        dataProvider.dataset.beforeDelete(() => UIkit.modal.confirm("Tem certeza?"));
-        dataProvider.dataset.beforeDelete(() => UIkit.modal.confirm("Mas tem certeza mesmo????"));
+    function setDatasetEventHandlers() {
+        dataProvider.dataset.beforeDelete((args) => {
+            return UIkit.modal.confirm(
+                translate("Delete the current record?"),
+                { labels: { cancel: translate("Dismiss"), ok: translate("Confirm") } }
+            );
+        });
     }
 
-    return {
-        definition: callback => loaded.then(data => callback(data)),
-        refresh,
-        render,
-    };
+    return Object.assign(
+        self,
+        {
+            definition: callback => loaded.then(data => callback(data)),
+            refresh,
+            render,
+        }
+    );
 }
 
 export default ComplexForm;

--- a/src/components/data_aware/complex_form.js
+++ b/src/components/data_aware/complex_form.js
@@ -84,10 +84,6 @@ function ComplexForm(context, complexId, parentNodeId) {
         formDom.render(built);
     }
 
-    async function handleBeforeDelete() {
-        return UIkit.modal.confirm("Tem certeza????");
-    }
-
     function setDatasetEventHandlers() {
         dataProvider.dataset.beforeDelete((args) => {
             return UIkit.modal.confirm(

--- a/src/components/data_aware/complex_form.js
+++ b/src/components/data_aware/complex_form.js
@@ -6,7 +6,14 @@ const refresh = (provider, complexId) => build(load(provider, complexId));
 
 function ComplexForm(context, complexId, parentNodeId) {
     let loaded, built, dataProvider, search;
-    const { ComplexFormProvider, PersistentQueryProvider, ComplexFormDom, DataToolbar, ModalSearch } = context,
+    const {
+        ComplexFormProvider,
+        PersistentQueryProvider,
+        ComplexFormDom,
+        DataToolbar,
+        ModalSearch,
+        UIkit
+    } = context,
           provider = ComplexFormProvider(context),
           formDom = ComplexFormDom(context, parentNodeId),
           refresh = () => build(load());
@@ -33,6 +40,7 @@ function ComplexForm(context, complexId, parentNodeId) {
                     queryId: data["dataset-name"],
                 }
             );
+            setDatasetEventHandlers();
             search = initSearch(dataProvider);
         });
     }
@@ -69,6 +77,15 @@ function ComplexForm(context, complexId, parentNodeId) {
             refresh();
         }
         formDom.render(built);
+    }
+
+    async function handleBeforeDelete() {
+        return UIkit.modal.confirm("Tem certeza????");
+    }
+
+    function setDatasetEventHandlers(args) {
+        dataProvider.dataset.beforeDelete(() => UIkit.modal.confirm("Tem certeza?"));
+        dataProvider.dataset.beforeDelete(() => UIkit.modal.confirm("Mas tem certeza mesmo????"));
     }
 
     return {

--- a/src/components/data_aware/data_set.js
+++ b/src/components/data_aware/data_set.js
@@ -186,7 +186,7 @@ function DataSet(context) {
 
     function _delete() {
         let recordCount = data.rows.length;
-        self.events.runConfirmation(events.beforeDelete, [self], (args) => {
+        self.events.runConfirmation(events.beforeDelete, [self, data.rows[data.recordIndex]], (args) => {
             data = deleteRow(data);
             if (recordCount != data.rows.length) {
                 self.events.run(events.afterDelete, [self]);
@@ -250,6 +250,7 @@ function DataSet(context) {
             fields: () => fields,
             rows: () => data.rows,
             recordIndex: () => data.recordIndex,
+            selectedRow: () => data.rows[data.recordIndex],
             recordCount: () => data.rows.length,
             state: () => data.state,
             eof: () => data.recordIndex == data.rows.length-1,

--- a/src/components/i18n/translations.js
+++ b/src/components/i18n/translations.js
@@ -8,11 +8,13 @@ const translations = {
             inputMaskGroupSeparator: ".",
             inputMaskDecimalSeparetor: ",",
             "Submit": "Confirmar",
+            "Confirm": "Confirmar",
             "Search": "Pesquisar",
             "Select": "Selecionar",
             "Dismiss": "Desistir",
             "4-digit-year": "Ano no formato AAAA",
             "Search by all available fields in any part of the text": "Pesquisar por todos os campos disponíveis em qualquer parte do texto",
+            "Delete the current record?": "Excluir este registro?",
             abbreviatedWeekDays: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"],
             abbreviatedMonthsNames: [
                 "Jan",


### PR DESCRIPTION
This PR implements the basic machinery in BaseComponent to allow running events that can prevent an action to be concluded. It also changes dataset beforeDelete event to use this new way of running events. 
ComplexForms adds beforeDelete with a confirmation dialog to dataProvider dataset.